### PR TITLE
feat: add logic to hardware/rp2040/prebuild.cmake to properly add cyw…

### DIFF
--- a/hardware/rp2040/prebuild.cmake
+++ b/hardware/rp2040/prebuild.cmake
@@ -5,3 +5,7 @@ include(${hardware_dir}/pico_sdk_import.cmake)
 
 set(hardware_includes ${hardware_dir})
 set(hardware_libs "pico_unique_id" "pico_stdlib")
+
+if(PICO_BOARD STREQUAL "pico_w")
+    list(APPEND hardware_libs "pico_cyw43_arch_none")
+endif()


### PR DESCRIPTION
Setting the board to "pico_w" in project.cmake as directed in the README does not add the necessary libraries to utilize the cyw43 wifi chip on the pico_w. This PR updates the hardware/rp2040/prebuild.cmake to conditionally add pico_cyw43_arch_none to the hardware_libs CMAKE variable, and to add a project define "WITH_CYW43" to enable conditional compilation of -- for example -- onboard LED code, which does not function on the pico_w due to the change in GPIO pinouts for the wireless module.