### PR TITLE
add_definition -DUSING_PICOW if board is pico_w

### DIFF
--- a/hardware/rp2040/CMakeLists.txt
+++ b/hardware/rp2040/CMakeLists.txt
@@ -23,7 +23,7 @@ function(hardware_build_extra)
     if(PICO_BOARD STREQUAL "pico_w")
         # Pass this parameter to the preprocessor if board type is pico_w
         # since some HW config needs to change
-        add_definitions(-DUSING_PICOW)
+        target_compile_definitions(cli PUBLIC -DUSING_PICOW)
     endif()
 
     # disable Pico STDIO - interacting with CLI will be done via RTOS task queue only, no printf


### PR DESCRIPTION
	-libraries now have the definition as well