### PR TITLE
Unify service arrays into a simple struct array

### DIFF
--- a/services/CMakeLists.txt
+++ b/services/CMakeLists.txt
@@ -7,4 +7,5 @@ target_sources(${PROJ_NAME} PRIVATE
     storman_service.c
     watchdog_service.c
     heartbeat_service.c
+    services.c
 )

--- a/services/services.c
+++ b/services/services.c
@@ -1,0 +1,31 @@
+#include "services.h"
+ 
+ const ServiceDesc_t service_descriptors[] = {
+    {
+        .name = xstr(SERVICE_NAME_USB), 
+        .service_func = usb_service,
+        .startup = true
+    },
+    {
+        .name = xstr(SERVICE_NAME_CLI), 
+        .service_func = cli_service,
+        .startup = true
+    }, 
+    {
+        .name = xstr(SERVICE_NAME_STORMAN), 
+        .service_func = storman_service,
+        .startup = true
+    }, 
+    {
+        .name = xstr(SERVICE_NAME_WATCHDOG), 
+        .service_func = watchdog_service,
+        .startup = true
+    }, 
+    {
+        .name = xstr(SERVICE_NAME_HEARTBEAT), 
+        .service_func = heartbeat_service,
+        .startup = false
+    }
+};
+
+const int service_descriptors_length = sizeof(service_descriptors)/sizeof(ServiceDesc_t);

--- a/services/services.c
+++ b/services/services.c
@@ -28,4 +28,4 @@
     }
 };
 
-const int service_descriptors_length = sizeof(service_descriptors)/sizeof(ServiceDesc_t);
+const size_t service_descriptors_length = sizeof(service_descriptors)/sizeof(ServiceDesc_t);

--- a/services/services.h
+++ b/services/services.h
@@ -203,44 +203,46 @@ BaseType_t heartbeat_service(void);
 
 
 /************************
- * Service Arrays
+ * Service Definitions
 *************************/
 
-// function ptr array of available service functions above for launching with taskmanager.
-// note that taskmanager itself is not in this list (it is a base service).
-// the corresponding string in service_strings[] below will be used to match the service.
-// service_functions[] and service_strings[] need to be in the same order!
 typedef BaseType_t (*ServiceFunc_t)(void);
-static const ServiceFunc_t service_functions[] = {
-    cli_service,
-    usb_service,
-    storman_service,
-    watchdog_service,
-    heartbeat_service
-};
 
-// string versions of service names, used when comparing against user input.
-// use xstr() to convert the SERVICE_NAME_ #define to a usable string.
-// the corresponding index number in the service_functions[] array above will be the
-// function ptr to launch the service.
-// service_functions[] and service_strings[] need to be in the same order!
-static const char *service_strings[] = {
-    xstr(SERVICE_NAME_CLI),
-    xstr(SERVICE_NAME_USB),
-    xstr(SERVICE_NAME_STORMAN),
-    xstr(SERVICE_NAME_WATCHDOG),
-    xstr(SERVICE_NAME_HEARTBEAT)
-};
+/**
+ * Structure to hold the service name, service function and whether or not this is a startup service.
+ * TODO: add __attribute__((PACKED))?
+ */
+typedef struct ServiceDesc {
+    /**
+     * String version of the service name, used when comparing against user input.
+     * It is recommended to use xstr() to convert the SERVICE_NAME_ #define to a usable string (e.g. xstr(SERVICE_NAME_HEARTBEAT)).
+    */
+    const char * const name;
+    /**
+     * Defines wether or not this service should automatically get launched by taskmanager at boot.
+    */
+    const bool startup;
+    /**
+     * Function pointer to the service that creates the respective FreeRTOS task.
+    */
+    ServiceFunc_t service_func;
+} ServiceDesc_t;
 
-// startup services - launched automatically by taskmanager at boot.
-// these strings should match with what is in service_strings[] for the intended service.
-// these can be in any order, the corresponding FreeRTOS tasked will be launched in this order.
-static const char *startup_services[] = {
-    "usb",
-    "cli",
-    "storagemanager",
-    "watchdog"
-};
+/**
+ * Holds all the services that can be launched with taskmanager.
+ * These can be in any order, the corresponding FreeRTOS tasks will be launched in this order.
+ * Note: taskmanager itself is not in this list (it is a base service).
+ * 
+ * Edit services.c to add your own services!
+*/
+extern const ServiceDesc_t service_descriptors[];
+
+/**
+ * Amount of entries in the service_desriptors array.
+*/
+extern const int service_descriptors_length;
+
+
 
 
 #endif /* SERVICES_H */

--- a/services/services.h
+++ b/services/services.h
@@ -238,9 +238,9 @@ typedef struct ServiceDesc {
 extern const ServiceDesc_t service_descriptors[];
 
 /**
- * Amount of entries in the service_desriptors array.
+ * Amount of entries in the service_descriptors array.
 */
-extern const int service_descriptors_length;
+extern const size_t service_descriptors_length;
 
 
 

--- a/services/taskman_service.c
+++ b/services/taskman_service.c
@@ -74,14 +74,13 @@ static void prvTaskManagerTask(void *pvParameters)
     // launch startup services
     cli_uart_puts(timestamp());
     cli_uart_puts("Starting all bootup services...\r\n");
-    int i, j;
-    for (i = 0; i < (sizeof(startup_services)/sizeof(startup_services[0])); i++) {
-        for (j = 0; j < (sizeof(service_strings)/sizeof(service_strings[0])); j++) {
-            if (strcmp(service_strings[j], startup_services[i]) == 0) {
-                service_functions[j]();
-            }
+    int i;
+    for (i = 0; i < service_descriptors_length;i++) {
+        if(service_descriptors[i].startup) {
+            service_descriptors[i].service_func();
         }
     }
+
 
     // At this point the system is fully running. Print a message
     cli_uart_puts(timestamp());


### PR DESCRIPTION
Hello! Congratulations on such a cool project 😃, immediately had to play around with it upon reading about it. After reading into the code to start defining my own services, I noticed that the service arrays could be unified into an array containing simple structs to improve a bunch of things (see below).

Instead of maintaining three different arrays, everything goes into an array of simple structs (see `services.c`), like:

```c
 const ServiceDesc_t service_descriptors[] = {
    {
        .name = xstr(SERVICE_NAME_USB), 
        .service_func = usb_service,
        .startup = true
    },
    // more service descriptor definitions here ...
};
```


- No longer need to watch out for `service_functions` and `service_strings` to have the same order 
- No longer need to watch out for spelling errors in the `startup_services`, just a simple boolean 
- No more `(sizeof(service_strings)/sizeof(service_strings[0]))` just access `service_descriptors_length`
- No more `strcmp` to find startup services in `taskman_service` just check the `startup` bool
- [No more duplicate static variables in memory (since they are now `extern` in the header file)](https://stackoverflow.com/a/3837513)