### PR TITLE
Services refactor

### DIFF
--- a/cli/node_bin.c
+++ b/cli/node_bin.c
@@ -229,8 +229,8 @@ static void service_exec_callback(struct ush_object *self, struct ush_file_descr
                 // Iterate through service_descriptors array to find the matching service index
                 int i;
                 for(i = 0; i < service_descriptors_length; i++) {
-                     if (strcmp(argv[2], service_descriptors[i].name) == 0) {
-                        service_descriptors[i].service_func();
+                    if (strcmp(argv[2], service_descriptors[i].name) == 0) {
+                        service_descriptors[i].service_func(); // call the function pointer for the matching service
                         break;
                     }
                     if (i == (service_descriptors_length - 1)) {
@@ -276,8 +276,7 @@ static void service_exec_callback(struct ush_object *self, struct ush_file_descr
                                             "Available Services\tStatus\r\n"
                                             "------------------------------------\r\n"
                                             USH_SHELL_FONT_STYLE_RESET;
-        
-        char *service_list_msg = pvPortMalloc(strlen(service_list_header) + (service_descriptors_length * sizeof(char*) * (configMAX_TASK_NAME_LEN + 16)));
+        char *service_list_msg = pvPortMalloc(strlen(service_list_header) + (service_descriptors_length * (configMAX_TASK_NAME_LEN + 16)));
         TaskHandle_t service_taskhandle;
         char service_state[12];
 

--- a/cli/node_bin.c
+++ b/cli/node_bin.c
@@ -276,7 +276,9 @@ static void service_exec_callback(struct ush_object *self, struct ush_file_descr
                                             "Available Services\tStatus\r\n"
                                             "------------------------------------\r\n"
                                             USH_SHELL_FONT_STYLE_RESET;
-        char *service_list_msg = pvPortMalloc(strlen(service_list_header) + (service_descriptors_length * (configMAX_TASK_NAME_LEN + 16)));
+        char *service_list_msg = pvPortMalloc(strlen(service_list_header) +
+                                 (service_descriptors_length *
+                                 (configMAX_TASK_NAME_LEN + 16))); // add 16 bytes per line for service state and whitespace
         TaskHandle_t service_taskhandle;
         char service_state[12];
 

--- a/services/CMakeLists.txt
+++ b/services/CMakeLists.txt
@@ -1,5 +1,6 @@
 # add source files to the top-level project
 target_sources(${PROJ_NAME} PRIVATE
+    services.c
     service_queues.c
     cli_service.c
     usb_service.c
@@ -7,5 +8,4 @@ target_sources(${PROJ_NAME} PRIVATE
     storman_service.c
     watchdog_service.c
     heartbeat_service.c
-    services.c
 )

--- a/services/CMakeLists.txt
+++ b/services/CMakeLists.txt
@@ -7,4 +7,5 @@ target_sources(${PROJ_NAME} PRIVATE
     storman_service.c
     watchdog_service.c
     heartbeat_service.c
+    services.c
 )

--- a/services/services.c
+++ b/services/services.c
@@ -1,0 +1,31 @@
+#include "services.h"
+ 
+ const ServiceDesc_t service_descriptors[] = {
+    {
+        .name = xstr(SERVICE_NAME_USB), 
+        .service_func = usb_service,
+        .startup = true
+    },
+    {
+        .name = xstr(SERVICE_NAME_CLI), 
+        .service_func = cli_service,
+        .startup = true
+    }, 
+    {
+        .name = xstr(SERVICE_NAME_STORMAN), 
+        .service_func = storman_service,
+        .startup = true
+    }, 
+    {
+        .name = xstr(SERVICE_NAME_WATCHDOG), 
+        .service_func = watchdog_service,
+        .startup = true
+    }, 
+    {
+        .name = xstr(SERVICE_NAME_HEARTBEAT), 
+        .service_func = heartbeat_service,
+        .startup = false
+    }
+};
+
+const size_t service_descriptors_length = sizeof(service_descriptors)/sizeof(ServiceDesc_t);

--- a/services/services.c
+++ b/services/services.c
@@ -1,6 +1,30 @@
+/******************************************************************************
+ * @file services.c
+ *
+ * @brief Defines the service descriptors for each system service declared in
+ *        services.h. These service descriptors are used to associate a service
+ *        name string with a service function pointer, as well as indicate if
+ *        the service should be started at boot. The individual service function
+ *        implementations and FreeRTOS APIs for registering the associated tasks
+ *        are contained in the source files for the respective services. Queues
+ *        used to pass data between services are implemented in service_queues.h.
+ *
+ * @author @nbes4 (github)
+ *
+ * @date 06-18-2024
+ * 
+ * @copyright Copyright (c) 2024 @nbes4 (github)
+ *            Released under the MIT License
+ * 
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
 #include "services.h"
- 
- const ServiceDesc_t service_descriptors[] = {
+
+// see services.h for more information on creating services
+// note: use xstr() to convert the SERVICE_NAME_ #define from services.h to a usable string
+// (e.g. xstr(SERVICE_NAME_HEARTBEAT))
+const ServiceDesc_t service_descriptors[] = {
     {
         .name = xstr(SERVICE_NAME_USB), 
         .service_func = usb_service,

--- a/services/services.c
+++ b/services/services.c
@@ -24,7 +24,7 @@
 // see services.h for more information on creating services
 // note: use xstr() to convert the SERVICE_NAME_ #define from services.h to a usable string
 // (e.g. xstr(SERVICE_NAME_HEARTBEAT))
-const ServiceDesc_t service_descriptors[] = {
+const service_desc_t service_descriptors[] = {
     {
         .name = xstr(SERVICE_NAME_USB), 
         .service_func = usb_service,
@@ -52,4 +52,4 @@ const ServiceDesc_t service_descriptors[] = {
     }
 };
 
-const size_t service_descriptors_length = sizeof(service_descriptors)/sizeof(ServiceDesc_t);
+const size_t service_descriptors_length = sizeof(service_descriptors)/sizeof(service_desc_t);

--- a/services/services.h
+++ b/services/services.h
@@ -203,44 +203,46 @@ BaseType_t heartbeat_service(void);
 
 
 /************************
- * Service Arrays
+ * Service Definitions
 *************************/
 
-// function ptr array of available service functions above for launching with taskmanager.
-// note that taskmanager itself is not in this list (it is a base service).
-// the corresponding string in service_strings[] below will be used to match the service.
-// service_functions[] and service_strings[] need to be in the same order!
 typedef BaseType_t (*ServiceFunc_t)(void);
-static const ServiceFunc_t service_functions[] = {
-    cli_service,
-    usb_service,
-    storman_service,
-    watchdog_service,
-    heartbeat_service
-};
 
-// string versions of service names, used when comparing against user input.
-// use xstr() to convert the SERVICE_NAME_ #define to a usable string.
-// the corresponding index number in the service_functions[] array above will be the
-// function ptr to launch the service.
-// service_functions[] and service_strings[] need to be in the same order!
-static const char *service_strings[] = {
-    xstr(SERVICE_NAME_CLI),
-    xstr(SERVICE_NAME_USB),
-    xstr(SERVICE_NAME_STORMAN),
-    xstr(SERVICE_NAME_WATCHDOG),
-    xstr(SERVICE_NAME_HEARTBEAT)
-};
+/**
+ * Structure to hold the service name, service function and whether or not this is a startup service.
+ * TODO: add __attribute__((PACKED))?
+ */
+typedef struct ServiceDesc {
+    /**
+     * String version of the service name, used when comparing against user input.
+     * It is recommended to use xstr() to convert the SERVICE_NAME_ #define to a usable string (e.g. xstr(SERVICE_NAME_HEARTBEAT)).
+    */
+    const char * const name;
+    /**
+     * Defines wether or not this service should automatically get launched by taskmanager at boot.
+    */
+    const bool startup;
+    /**
+     * Function pointer to the service that creates the respective FreeRTOS task.
+    */
+    ServiceFunc_t service_func;
+} ServiceDesc_t;
 
-// startup services - launched automatically by taskmanager at boot.
-// these strings should match with what is in service_strings[] for the intended service.
-// these can be in any order, the corresponding FreeRTOS tasked will be launched in this order.
-static const char *startup_services[] = {
-    "usb",
-    "cli",
-    "storagemanager",
-    "watchdog"
-};
+/**
+ * Holds all the services that can be launched with taskmanager.
+ * These can be in any order, the corresponding FreeRTOS tasks will be launched in this order.
+ * Note: taskmanager itself is not in this list (it is a base service).
+ * 
+ * Edit services.c to add your own services!
+*/
+extern const ServiceDesc_t service_descriptors[];
+
+/**
+ * Amount of entries in the service_descriptors array.
+*/
+extern const size_t service_descriptors_length;
+
+
 
 
 #endif /* SERVICES_H */

--- a/services/services.h
+++ b/services/services.h
@@ -216,10 +216,10 @@ BaseType_t heartbeat_service(void);
 *************************/
 
 // service function pointer typedef
-typedef BaseType_t (*ServiceFunc_t)(void);
+typedef BaseType_t (*service_func_t)(void);
 
 // service descriptor structure to hold the service name, service function pointer and startup flag
-typedef struct ServiceDesc_t {
+typedef struct service_desc_t {
     // string version of the service name, used when comparing against user input
     const char * const name;
 
@@ -227,14 +227,14 @@ typedef struct ServiceDesc_t {
     const bool startup;
 
     //Function pointer to the service that creates the respective FreeRTOS task - declared in services.h
-    ServiceFunc_t service_func;
-} ServiceDesc_t;
+    service_func_t service_func;
+} service_desc_t;
 
 // holds all the services that can be launched with taskmanager.
 // these can be in any order, the corresponding FreeRTOS tasks will be launched in this order.
 // note: taskmanager itself is not in this array (it is a base service).
 // edit services.c to add your own services!
-extern const ServiceDesc_t service_descriptors[];
+extern const service_desc_t service_descriptors[];
 
 // number of service descriptors in the array is used to iterate through services
 // for startup and interaction

--- a/services/taskman_service.c
+++ b/services/taskman_service.c
@@ -75,7 +75,7 @@ static void prvTaskManagerTask(void *pvParameters)
     cli_uart_puts(timestamp());
     cli_uart_puts("Starting all bootup services...\r\n");
     int i;
-    for (i = 0; i < service_descriptors_length;i++) {
+    for (i = 0; i < service_descriptors_length; i++) {
         if(service_descriptors[i].startup) {
             service_descriptors[i].service_func();
         }

--- a/services/taskman_service.c
+++ b/services/taskman_service.c
@@ -74,14 +74,13 @@ static void prvTaskManagerTask(void *pvParameters)
     // launch startup services
     cli_uart_puts(timestamp());
     cli_uart_puts("Starting all bootup services...\r\n");
-    int i, j;
-    for (i = 0; i < (sizeof(startup_services)/sizeof(startup_services[0])); i++) {
-        for (j = 0; j < (sizeof(service_strings)/sizeof(service_strings[0])); j++) {
-            if (strcmp(service_strings[j], startup_services[i]) == 0) {
-                service_functions[j]();
-            }
+    int i;
+    for (i = 0; i < service_descriptors_length;i++) {
+        if(service_descriptors[i].startup) {
+            service_descriptors[i].service_func();
         }
     }
+
 
     // At this point the system is fully running. Print a message
     cli_uart_puts(timestamp());

--- a/version.h
+++ b/version.h
@@ -19,7 +19,7 @@
 // maintain BreadboardOS version so it can be tracked along with custom project
 #define BBOS_NAME          "breadboard-os" // do not change
 #define BBOS_VERSION_MAJOR 0               // changed only for major release update
-#define BBOS_VERSION_MINOR 1               // changed only for minor release update
+#define BBOS_VERSION_MINOR 2               // changed only for minor release update
 
 // custom project name and version is defined in top level CMakeLists.txt
 // look for PROJ_NAME and PROJ_VER


### PR DESCRIPTION
Refactoring the `servicemanager` framework to use a "service descriptors" structure rather than discrete arrays of names, function pointers, and run-at-boot flags, resulting in a simpler and more elegant way to implement new services. Thanks to @nbes4 for this contribution.