### PR TITLE
33 pico 2 w support

### DIFF
--- a/hardware/rp2xxx/prebuild.cmake
+++ b/hardware/rp2xxx/prebuild.cmake
@@ -19,11 +19,14 @@ set(hardware_libs   "pico_unique_id"
 )
 
 # FreeRTOS port subdirectory for this platform (relative to $FREERTOS_KERNEL_PATH)
-# If it is a RP2350 board the board name needs to be added here to select the right port
-if(PICO_BOARD STREQUAL "pico2" OR PICO_BOARD STREQUAL "pico2_w")
+# all of the "boards" from the link above should be handled here to categorize
+# them as RP2040 or RP2350 type
+if(PICO_BOARD STREQUAL "pico" OR PICO_BOARD STREQUAL "pico_w")
+    set(freertos_port_path "portable/ThirdParty/GCC/RP2040/FreeRTOS_Kernel_import.cmake")
+elseif(PICO_BOARD STREQUAL "pico2" OR PICO_BOARD STREQUAL "pico2_w")
     set(freertos_port_path "portable/ThirdParty/Community-Supported-Ports/GCC/RP2350_ARM_NTZ/FreeRTOS_Kernel_import.cmake")
 else()
-    set(freertos_port_path "portable/ThirdParty/GCC/RP2040/FreeRTOS_Kernel_import.cmake")
+    message(FATAL_ERROR "Board type unknown to BBOS: ${PICO_BOARD} - see hardware/rp2xxx/prebuild.cmake for instructions")
 endif()
 
 # If using a Pico wireless variant, include the cyw43 library

--- a/hardware/rp2xxx/prebuild.cmake
+++ b/hardware/rp2xxx/prebuild.cmake
@@ -20,7 +20,7 @@ set(hardware_libs   "pico_unique_id"
 
 # FreeRTOS port subdirectory for this platform (relative to $FREERTOS_KERNEL_PATH)
 # If it is a RP2350 board the board name needs to be added here to select the right port
-if(PICO_BOARD STREQUAL "pico2")
+if(PICO_BOARD STREQUAL "pico2" OR PICO_BOARD STREQUAL "pico2_w")
     set(freertos_port_path "portable/ThirdParty/GCC/RP2350_ARM_NTZ/FreeRTOS_Kernel_import.cmake")
 else()
     set(freertos_port_path "portable/ThirdParty/GCC/RP2040/FreeRTOS_Kernel_import.cmake")
@@ -28,7 +28,7 @@ endif()
 
 # If using a Pico wireless variant, include the cyw43 library
 # Any other board names that use cyw43 would have to be added here too
-if(PICO_BOARD STREQUAL "pico_w")
+if(PICO_BOARD STREQUAL "pico_w" OR PICO_BOARD STREQUAL "pico2_w")
     list(APPEND hardware_libs pico_cyw43_arch_none)
     add_compile_definitions(USING_CYW43)
 endif()


### PR DESCRIPTION
Adding support for RP2350 (both Raspberry Pi Pico 2 and Pico 2 W), using mainline versions of both FreeRTOS and the Pico SDK, which have recently merged in updates to support RP2350